### PR TITLE
Shell Step parameter fixed and Batch step added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # labelled-steps-plugin
 
-Currently this plugin provides a replacement for the [`sh` step][sh] in Jenkins
+Currently this plugin provides a replacement for the [`sh`][sh] and [`bat`][bat] steps in Jenkins
 pipelines to allow displaying a custom label in the BlueOcean UI.
 
 
@@ -26,5 +26,6 @@ labelledShell label: 'Building the universe from scratch...', script: """
 
 
 [sh]: https://jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#sh-shell-script
+[bat]: https://jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#bat-windows-batch-script
 [JENKINS-36933]: https://issues.jenkins-ci.org/browse/JENKINS-36933
 [JENKINS-37324]: https://issues.jenkins-ci.org/browse/JENKINS-37324

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.level>7</java.level>
     </properties>
     <name>Labelled Pipeline Steps Plugin</name>
-    <description>Currently provides a replacement for the `sh` pipeline step to allow displaying a custom label in the BlueOcean UI.</description>
+    <description>Currently provides a replacement for the `sh` and `bat` pipeline steps to allow displaying a custom label in the BlueOcean UI.</description>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/me/vickychijwani/jenkins/LabelledBatchStep.java
+++ b/src/main/java/me/vickychijwani/jenkins/LabelledBatchStep.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, offa
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package me.vickychijwani.jenkins;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.durabletask.DurableTask;
+import org.jenkinsci.plugins.durabletask.WindowsBatchScript;
+import org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+/**
+ * Runs a Batch script asynchronously on a slave.
+ *
+ * This is a lightly-modified version of the official BatchStep:
+ * https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/BatchScriptStep.java
+ */
+public class LabelledBatchStep extends DurableTaskStep {
+    private final String script;
+    private String label;
+
+    @DataBoundConstructor
+    public LabelledBatchStep(String script) {
+        if (script == null) {
+            throw new IllegalArgumentException();
+        }
+        this.script = script;
+    }
+
+    public String getScript() {
+        return script;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    @Override protected DurableTask task() {
+        return new WindowsBatchScript(script);
+    }
+
+
+    @Extension
+    public static final class DescriptorImpl extends DurableTaskStepDescriptor {
+
+        @Override public String getDisplayName() {
+            return "Batch Script";
+        }
+
+        @Override public String getFunctionName() {
+            return "labelledBatch";
+        }
+
+        @CheckForNull
+        @Override
+        public String argumentsToString(@Nonnull Map<String, Object> namedArgs) {
+            if (namedArgs.containsKey("label")) {
+                return (String) namedArgs.get("label");
+            }
+
+            return null;
+        }
+
+    }
+
+}

--- a/src/main/java/me/vickychijwani/jenkins/LabelledShellStep.java
+++ b/src/main/java/me/vickychijwani/jenkins/LabelledShellStep.java
@@ -32,6 +32,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -46,6 +47,7 @@ import java.util.Map;
 public final class LabelledShellStep extends DurableTaskStep {
 
     private final String script;
+    private String label;
 
     @DataBoundConstructor public LabelledShellStep(String script) {
         if (script==null)
@@ -55,6 +57,15 @@ public final class LabelledShellStep extends DurableTaskStep {
 
     public String getScript() {
         return script;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
     }
 
     @Override protected DurableTask task() {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    TODO
+    Provides a replacement for the sh and bat pipeline steps to allow displaying a custom label in the BlueOcean UI.
 </div>


### PR DESCRIPTION
This PR fixes the missing `label` parameter of the `labelledShell()` step, adds the ` bat()` counterpart and some documentation.

### `labelledShell()` Parameter fix

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 8: Invalid parameter "label", did you mean "script"? @ line 8, column 51.
   lledShell(script: 'echo xyz', label: 'Te
                                 ^
```
#### Minimal Example:

```groovy
pipeline {
    agent any
    
    stages {
        stage("Test") {
            steps {
                sh("echo abc")
                labelledShell(script: 'echo xyz', label: 'Test Step')
            }
        }
    }
}
```

Fixed by introducing the `label` parameter.

### Added `labelledBatch()` step

Analogue to `labelledShell()` therer's a `labelledBatch()` to bring this feature to Windows Agents. 

